### PR TITLE
Simpler Collection Types

### DIFF
--- a/src/androidTest/java/com/kissmetrics/sdk/VerificationImplTest.java
+++ b/src/androidTest/java/com/kissmetrics/sdk/VerificationImplTest.java
@@ -43,7 +43,7 @@ public class VerificationImplTest extends ActivityTestCase implements Verificati
 			testUrl = new URL("http://www.google.com/"); // <- No special url required, just needs to be valid.
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
-		} 
+		}
 		
 		mockConnection = new MockHttpURLConnection(testUrl);
 		mockConnection.setExpectedGetInputStream(new ByteArrayInputStream("".getBytes()));//<- Not always used but required for mock, so empty 

--- a/src/main/java/com/kissmetrics/sdk/Archiver.java
+++ b/src/main/java/com/kissmetrics/sdk/Archiver.java
@@ -17,7 +17,7 @@
 
 package com.kissmetrics.sdk;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import com.kissmetrics.sdk.KISSmetricsAPI.RecordCondition;
 
@@ -33,8 +33,8 @@ public interface Archiver {
 	void archiveHasGenericIdentity(boolean hasGenericIdentity);
 	void archiveAppVersion(String appVersion);
 	void archiveFirstIdentity(String identity);
-	void archiveEvent(String name, HashMap<String, String> properties, RecordCondition condition);
-	void archiveProperties(HashMap<String, String> properties);
+	void archiveEvent(String name, Map<String, String> properties, RecordCondition condition);
+	void archiveProperties(Map<String, String> properties);
 	void archiveDistinctProperty(String name, String value);
 	void archiveIdentity(String identity);
 	void archiveAlias(String alias, String identity);

--- a/src/main/java/com/kissmetrics/sdk/ArchiverImpl.java
+++ b/src/main/java/com/kissmetrics/sdk/ArchiverImpl.java
@@ -24,6 +24,7 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.kissmetrics.sdk.KISSmetricsAPI.RecordCondition;
 
@@ -74,11 +75,10 @@ public class ArchiverImpl implements Archiver {
 	/**
 	 * Initializes the private singleton.
 	 * 
-	 * @param productKey  KISSmetrics product key
+	 * @param key  KISSmetrics product key
 	 * @param applicationContext  Android application context
 	 */
-	private ArchiverImpl(final String key, final Context applicationContext) {
-		
+	private ArchiverImpl(String key, Context applicationContext) {
 		this.key = key;
 		this.context = applicationContext;
 		this.queryEncoder = new QueryEncoder(this.key, CLIENT_TYPE, Connection.USER_AGENT);
@@ -102,8 +102,8 @@ public class ArchiverImpl implements Archiver {
 	 * @param applicationContext  Android application context
 	 * @return Archiver singleton instance
 	 */
-	public static synchronized ArchiverImpl sharedArchiver(final String productKey, 
-														   final Context applicationContext) {
+	public static synchronized ArchiverImpl sharedArchiver(String productKey,
+														   Context applicationContext) {
 		if (sharedArchiver == null) {
 			sharedArchiver = new ArchiverImpl(productKey, applicationContext);
 		}
@@ -149,7 +149,7 @@ public class ArchiverImpl implements Archiver {
 			// The KISSmetrics SDK should not cause a customer's app to crash.
 			// If a FileNotFoundException or IOException arises we define default settings 
 			// and carry on. 
-			Log.w(KISSmetricsAPI.TAG, "Unable to unarchive saved settings");
+			Log.w(KISSmetricsAPI.TAG, "Unable to unarchive saved settings", e);
 		}
 		
 		// The file doesn't exist yet or there was an error in reading the file. 
@@ -196,7 +196,6 @@ public class ArchiverImpl implements Archiver {
 			Log.w(KISSmetricsAPI.TAG, "Unable to archive settings", e);
 		}
 	}
-    
 	
 	/**
 	 * Unarchive's identity from Shared Preferences.
@@ -329,7 +328,6 @@ public class ArchiverImpl implements Archiver {
 	 */
     @SuppressWarnings("unchecked")
 	private void unarchiveSavedProperties() {
-    	
     	// Not synch'd as should always be called inside of a sync block !!
     	try {
     		FileInputStream fis = this.context.openFileInput(SAVED_PROPERTIES_FILE);
@@ -431,8 +429,6 @@ public class ArchiverImpl implements Archiver {
     	return System.currentTimeMillis() / 1000L;
     }
 
-	
-    
     /************************************************
      * Public methods
      ************************************************/
@@ -466,7 +462,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param doTrack  Setting to control recording of aliases, events and properties.
      */
-    public void archiveDoTrack(final boolean doTrack) {
+    public void archiveDoTrack(boolean doTrack) {
     	
     	synchronized (this) {
     		this.settings.put(DO_TRACK_KEY, doTrack);
@@ -480,7 +476,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param doSend  Setting to control the uploading of aliases, events and properties.
      */
-    public void archiveDoSend(final boolean doSend) {
+    public void archiveDoSend(boolean doSend) {
     	
     	synchronized (this) {
     		this.settings.put(DO_SEND_KEY, doSend);
@@ -494,7 +490,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param baseUrl Setting for API base URL path
      */
-    public void archiveBaseUrl(final String baseUrl) {
+    public void archiveBaseUrl(String baseUrl) {
     	
     	// Protect from null or empty string
     	if (baseUrl == null || baseUrl.length() == 0) {
@@ -514,7 +510,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param expDate  Milliseconds from unix epoch when verification expires.
      */
-    public void archiveVerificationExpDate(final long expDate) {
+    public void archiveVerificationExpDate(long expDate) {
     	synchronized (this) {
     		this.settings.put(VERIFICATION_EXP_DATE_KEY, expDate);
     		this.archiveSettings();
@@ -539,7 +535,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param appVersion String app version name.
      */
-    public void archiveAppVersion(final String appVersion) {
+    public void archiveAppVersion(String appVersion) {
     	synchronized (this) {
     		this.settings.put(APP_VERSION_KEY, appVersion);
     		this.archiveSettings();
@@ -554,7 +550,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param identity  A new, anonymous identity
      */
-    public void archiveFirstIdentity(final String identity) {
+    public void archiveFirstIdentity(String identity) {
 
     	if (identity == null || identity.length() == 0) {
     		return;
@@ -571,7 +567,7 @@ public class ArchiverImpl implements Archiver {
     	}
     }
    
-    public void archiveEvent(final String name, final HashMap<String, String> properties, RecordCondition condition) {
+    public void archiveEvent(String name, Map<String, String> properties, RecordCondition condition) {
     	
     	if (name == null || name.length() == 0) {
     		Log.w(KISSmetricsAPI.TAG, 
@@ -627,7 +623,7 @@ public class ArchiverImpl implements Archiver {
      * @param name  Name of the event to record
      * @param properties  A HashMap of 1 or more properties, or null
      */
-    private void archiveEvent(final String name, final HashMap<String, String> properties) {
+    private void archiveEvent(String name, Map<String, String> properties) {
 
     	synchronized (this) {
 			String theUrl = this.queryEncoder.createEventQuery(name, properties, 
@@ -645,7 +641,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param properties  HashMap of 1 or more properties.
      */
-    public void archiveProperties(final HashMap<String, String> properties) {
+    public void archiveProperties(Map<String, String> properties) {
 
     	if (properties == null || properties.isEmpty()) {
     		Log.w(KISSmetricsAPI.TAG, 
@@ -671,8 +667,8 @@ public class ArchiverImpl implements Archiver {
      * @param name  Property name(key)
      * @param value  Property value for name(key)
      */
-    public void archiveDistinctProperty(final String name, final String value) {
-    	
+    public void archiveDistinctProperty(String name, String value) {
+
     	synchronized (this) {
     		
     		String propertyValue = this.savedProperties.get(name);
@@ -701,8 +697,8 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param identity  A new user identity
      */
-    public void archiveIdentity(final String identity) {
-    	
+    public void archiveIdentity(String identity) {
+
     	if (identity == null || identity.length() == 0 || identity.equals(this.lastIdentity)) {
     		Log.w(KISSmetricsAPI.TAG, "Attempted to use null, empty or existing identity. Ignoring");
     		return;
@@ -744,7 +740,7 @@ public class ArchiverImpl implements Archiver {
      * @param alias  An alias to an identity
      * @param identity  A known user identity
      */
-    public void archiveAlias(final String alias, final String identity) {
+    public void archiveAlias(String alias, String identity) {
     	
     	if (alias == null || alias.length() == 0 || identity == null || identity.length() == 0) {
     		Log.w(KISSmetricsAPI.TAG, 
@@ -807,7 +803,7 @@ public class ArchiverImpl implements Archiver {
      * @param index  Query string index in the sendQueue.
      * @return Query string of the requested index.
      */
-    public String getQueryString(final int index) {
+    public String getQueryString(int index) {
     	
     	synchronized (this) {
     		if (sendQueue.isEmpty()) {
@@ -825,7 +821,7 @@ public class ArchiverImpl implements Archiver {
      * 
      * @param index  Query string index in the sendQueue
      */
-    public void removeQueryString(final int index) {
+    public void removeQueryString(int index) {
     	
     	synchronized (this) {
     		// As an added precaution we check the length of the sendQueue before removing.

--- a/src/main/java/com/kissmetrics/sdk/ConnectionImpl.java
+++ b/src/main/java/com/kissmetrics/sdk/ConnectionImpl.java
@@ -55,7 +55,7 @@ public class ConnectionImpl implements Connection {
 	 * @param urlString  URL encoded API query string
 	 * @delegate delegate Object implementing the ConnectionDelegate interface
 	 */
-	public void sendRecord(final String urlString, final ConnectionDelegate delegate) {
+	public void sendRecord(String urlString, ConnectionDelegate delegate) {
 		URL url = null;
 		connection = null;
 		
@@ -92,7 +92,7 @@ public class ConnectionImpl implements Connection {
         connection = null;
       }
 
-      if (malformed != true && (responseCode == 200 || responseCode == 304)) {
+      if (!malformed && (responseCode == 200 || responseCode == 304)) {
         success = true;
       } else {
         success = false;

--- a/src/main/java/com/kissmetrics/sdk/KISSmetricsAPI.java
+++ b/src/main/java/com/kissmetrics/sdk/KISSmetricsAPI.java
@@ -17,7 +17,7 @@
 
 package com.kissmetrics.sdk;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -135,8 +135,8 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 *            Android application context.
 	 * @return KISSmetricsAPI singleton instance.
 	 */
-  public static synchronized KISSmetricsAPI sharedAPI(final String productKey,
-                                                      final Context applicationContext)
+  public static synchronized KISSmetricsAPI sharedAPI(String productKey,
+                                                      Context applicationContext)
   {
 		if (sharedAPI == null) {
 			sharedAPI = new KISSmetricsAPI(productKey, applicationContext);
@@ -247,9 +247,9 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 * @param alias
 	 * @param identity
 	 */
-	public void alias(final String alias, final String identity) {
+	public void alias(String alias, String identity) {
 		dataExecutor.execute(trackingRunnables.alias(alias, identity,
-				ArchiverImpl.sharedArchiver(), this));
+            ArchiverImpl.sharedArchiver(), this));
 	}
 
 	/**
@@ -258,7 +258,7 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 */
 	public void clearIdentity() {
 		dataExecutor.execute(trackingRunnables.clearIdentity(generateID(),
-				ArchiverImpl.sharedArchiver()));
+            ArchiverImpl.sharedArchiver()));
 	}
 
 	/**
@@ -271,7 +271,7 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 */
 	// TODO: We should allow for recording properties as numbers or strings.
 	public void record(String name,
-			               HashMap<String, String> properties)
+			               Map<String, String> properties)
   {
 		record(name, properties, RecordCondition.RECORD_ALWAYS);
 	}
@@ -303,7 +303,7 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 * 				event has already been recorded, any properties passed will also be 
 	 * 				ignored.
 	 */
-	public void record(String name, HashMap<String, String> properties, RecordCondition condition) {
+	public void record(String name, Map<String, String> properties, RecordCondition condition) {
 		dataExecutor.execute(trackingRunnables.record(name, properties, condition,
 				ArchiverImpl.sharedArchiver(), this));
 
@@ -340,9 +340,9 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 *            User properties
 	 */
 	// TODO: We should allow for recording properties as numbers or strings.
-	public void set(HashMap<String, String> properties) {
+	public void set(Map<String, String> properties) {
 		dataExecutor.execute(trackingRunnables.set(properties,
-				ArchiverImpl.sharedArchiver(), this));
+            ArchiverImpl.sharedArchiver(), this));
 	}
 
 	/**
@@ -505,7 +505,7 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	}
 
 	/**
-	 * @deprecated use {@link record(String name, HashMap<String, String>
+	 * @deprecated use {@link record(String name, Map<String, String>
 	 *             properties)} instead. 'recordEvent' method name has been
 	 *             changed to 'record' for consistency across our various APIs.
 	 * 
@@ -517,12 +517,12 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 *            Event properties or null
 	 */
 	@Deprecated
-	public void recordEvent(String name, HashMap<String, String> properties) {
+	public void recordEvent(String name, Map<String, String> properties) {
 		record(name, properties);
 	}
 
 	/**
-	 * @deprecated use {@link record(String name, HashMap<String, String>
+	 * @deprecated use {@link record(String name, Map<String, String>
 	 *             properties), RecordCondition condition} instead. 'recordOnce' 
 	 *             would only restrict the recording of events per identity. A 
 	 *             more flexible solution was needed to allow recording of 
@@ -538,7 +538,7 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	}
 	
 	/**
-	 * @deprecated use {@link set(HashMap<String, String> properties)} instead.
+	 * @deprecated use {@link set(Map<String, String> properties)} instead.
 	 *             'setProperties' method name has been changed to 'set' for
 	 *             consistency across our various APIs.
 	 * 
@@ -546,7 +546,7 @@ public final class KISSmetricsAPI implements VerificationDelegate {
 	 *            User properties
 	 */
 	@Deprecated
-	public void setProperties(HashMap<String, String> properties) {
+	public void setProperties(Map<String, String> properties) {
 		set(properties);
 	}
 }

--- a/src/main/java/com/kissmetrics/sdk/QueryEncoder.java
+++ b/src/main/java/com/kissmetrics/sdk/QueryEncoder.java
@@ -20,6 +20,7 @@ package com.kissmetrics.sdk;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.HashMap;
+import java.util.Map;
 
 import android.util.Log;
 
@@ -56,7 +57,7 @@ public class QueryEncoder {
    * @param properties  HashMap of user or event properties
    * @return boolean  true if timestamp has been set in these properties
    */
-  private boolean propertiesContainTimestamp(HashMap<String, String> properties) {
+  private boolean propertiesContainTimestamp(Map<String, String> properties) {
     if (properties != null && properties.containsKey("_d") && properties.containsKey("_t")) {
       return true;
     }
@@ -116,7 +117,7 @@ public class QueryEncoder {
 	 * @param properties  User or Event properties.
 	 * @return the URL encoded properties
 	 */
-	public String encodeProperties(HashMap<String, String> properties) {
+	public String encodeProperties(Map<String, String> properties) {
 		if (properties == null || properties.isEmpty()) {
 			return "";
 		}
@@ -176,13 +177,13 @@ public class QueryEncoder {
 	 * @return the URL encoded query string
 	 */
 	public String createEventQuery(String name,
-                                 HashMap<String, String>properties,
+                                 Map<String, String>properties,
 								                 String identity,
                                  long timestamp)
   {
-		String theUrl = String.format("%s?_k=%s&_c=%s&_u=%s&_p=%s&_n=%s", EVENT_PATH, key, 
-									                clientType, userAgent, encodeIdentity(identity),
-									                encodeEvent(name));
+		String theUrl = String.format("%s?_k=%s&_c=%s&_u=%s&_p=%s&_n=%s", EVENT_PATH, key,
+            clientType, userAgent, encodeIdentity(identity),
+            encodeEvent(name));
 
 		if (!propertiesContainTimestamp(properties)) {
 			theUrl += String.format("&_d=1&_t=%d", timestamp);
@@ -201,7 +202,7 @@ public class QueryEncoder {
 	 * @param timestamp  A unix epoch timestamp to apply if _t & _d have not been set in properties
 	 * @return the URL encoded query string
 	 */
-  public String createPropertiesQuery(HashMap<String, String>properties,
+  public String createPropertiesQuery(Map<String, String>properties,
                                       String identity,
                                       long timestamp)
   {

--- a/src/main/java/com/kissmetrics/sdk/TrackingRunnables.java
+++ b/src/main/java/com/kissmetrics/sdk/TrackingRunnables.java
@@ -17,9 +17,9 @@
 
 package com.kissmetrics.sdk;
 
-import java.util.HashMap;
-
 import com.kissmetrics.sdk.KISSmetricsAPI.RecordCondition;
+
+import java.util.Map;
 
 /**
  * TrackingRunnables interface
@@ -70,7 +70,7 @@ public interface TrackingRunnables {
 	 * @param kmapi  The instance of KISSmetricsAPI where initiation of recursive send should occur.
 	 * @return A Runnable object that will run appropriate tasks for the current tracking state.
 	 */
-	Runnable record(String name, HashMap<String, String> properties,
+	Runnable record(String name, Map<String, String> properties,
 						      RecordCondition condition, Archiver archiver,
 						      KISSmetricsAPI kmapi);
 	
@@ -94,7 +94,7 @@ public interface TrackingRunnables {
 	 * @param kmapi  The instance of KISSmetricsAPI where initiation of recursive send should occur.
 	 * @return A Runnable object that will run appropriate tasks for the current tracking state.
 	 */
-	Runnable set(HashMap<String, String> properties, Archiver archiver, KISSmetricsAPI kmapi);
+	Runnable set(Map<String, String> properties, Archiver archiver, KISSmetricsAPI kmapi);
 
 	/**
 	 * Creates a Runnable to archive and send properties with a new or different value for the 

--- a/src/main/java/com/kissmetrics/sdk/TrackingRunnablesNonTrackingState.java
+++ b/src/main/java/com/kissmetrics/sdk/TrackingRunnablesNonTrackingState.java
@@ -18,6 +18,7 @@
 package com.kissmetrics.sdk;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import com.kissmetrics.sdk.KISSmetricsAPI.RecordCondition;
 
@@ -95,7 +96,7 @@ public class TrackingRunnablesNonTrackingState implements TrackingRunnables {
 	 * @return A no action Runnable.
 	 */
 	public Runnable record(String name,
-                         HashMap<String, String> properties,
+                         Map<String, String> properties,
                          RecordCondition condition,
 						             Archiver archiver,
                          KISSmetricsAPI kmapi)
@@ -137,7 +138,7 @@ public class TrackingRunnablesNonTrackingState implements TrackingRunnables {
 	 * @param kmapi  The instance of KISSmetricsAPI where initiation of recursive send should occur.
 	 * @return A no action Runnable.
 	 */
-	public Runnable set(HashMap<String, String> properties,
+	public Runnable set(Map<String, String> properties,
                       Archiver archiver,
 						          KISSmetricsAPI kmapi)
   {
@@ -169,5 +170,4 @@ public class TrackingRunnablesNonTrackingState implements TrackingRunnables {
 
 		return runnable;
 	}
-
 }

--- a/src/main/java/com/kissmetrics/sdk/TrackingRunnablesTrackingState.java
+++ b/src/main/java/com/kissmetrics/sdk/TrackingRunnablesTrackingState.java
@@ -18,6 +18,7 @@
 package com.kissmetrics.sdk;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import com.kissmetrics.sdk.KISSmetricsAPI.RecordCondition;
 
@@ -104,7 +105,7 @@ public class TrackingRunnablesTrackingState implements TrackingRunnables {
 	 * @return A Runnable object that will archive and send an event.
 	 */
 	public Runnable record(final String name,
-                         final HashMap<String, String> properties,
+                         final Map<String, String> properties,
 						             final RecordCondition condition,
                          final Archiver archiver,
 						             final KISSmetricsAPI kmapi)
@@ -150,7 +151,7 @@ public class TrackingRunnablesTrackingState implements TrackingRunnables {
 	 * @param kmapi  The instance of KISSmetricsAPI where initiation of recursive send should occur.
 	 * @return A Runnable object that will archive and send 1 or more properties.
 	 */
-	public Runnable set(final HashMap<String, String> properties,
+	public Runnable set(final Map<String, String> properties,
                       final Archiver archiver,
 						          final KISSmetricsAPI kmapi)
   {


### PR DESCRIPTION
Changes parameter lists to use interface/simple collection types (such as `Map`) instead of specific implementations (such as `HashMap`).

Removes a few `final` keywords that I missed previously as well.